### PR TITLE
Fix typos and standardize terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ features like image and latex embedding will not render on Github, though should
 still be readable. If you would like to read them with latex rendering, a
 hack solution might be to copy them to a HackMD document. 
 
-The group open to everyone, and runs out of the [ZK hack discord
+The group is open to everyone, and runs out of the [ZK hack discord
 server](https://www.zkhack.dev/) by myself and the nice folks at the Zero Knowledge
 Podcast.
 

--- a/n-pazk-ch3.md
+++ b/n-pazk-ch3.md
@@ -1,7 +1,7 @@
 #note #pazk #cryptography 
 A short chapter covering preliminaries like the Schwartz Zippel Lemma, multilinear functions, low degree extensions, and several conceptual clarifications.
 ## key stuff
-- interactive proof system definition: a pair of algorithms V,P, with sufficiently smol completeness and soundness error
+- interactive proof system definition: a pair of algorithms V,P, with sufficiently small completeness and soundness error
 - Argument system definition - an IP that is sound against polynomial time prover adversaries (computational soundness)
 - Schwartz zippel lemma - gives upper bounds on multivariate polynomial collisions
 - Multilinear polynomials - our main character in the next chapter
@@ -18,7 +18,7 @@ Section 3.3 clarifies several definitions.
 - All our protocols will naturally have perfect completeness, though we could just as easily use imperfectly complete ones.
 - the soundness error convention of 1/3 is merely convention; soundness error in practice will be proportional to $1/|\mathbb F|$ 
 - public coin randomness is what we will almost always use, so as to take advantage of the Fiat Shamir transformation. Any private coin IP can be simulated by a public coin IP.
-- Deterministic malicious Prover strategies will naturally be stronger adversaries than Probalistic malicious prover strategies.
+- Deterministic malicious Prover strategies will naturally be stronger adversaries than Probabilistic malicious prover strategies.
 
 A passing, skimmable set of remarks is made on Complexity Theoretic notation's equivalence.
 


### PR DESCRIPTION
File: n-pazk-ch3.md
smol → small
Probalistic → Probabilistic

File: README.md
Removed duplicate line:
Old: The group open to everyone, and runs out of the [ZK hack discord
New: The group is open to everyone, and runs out of the [ZK hack discord
Reason: Eliminates redundant text and improves grammar with proper "is" verb

